### PR TITLE
Legend hover updates value inside donut chart circle

### DIFF
--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -130,7 +130,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
                 focusedArcId={this.state.focusedArcId || ''}
                 href={href}
                 calloutId={this._calloutId}
-                valueInsideDonut={valueInsideDonut}
+                valueInsideDonut={this._valueInsideDonut(valueInsideDonut!, chartData!)}
                 theme={theme!}
               />
             </svg>
@@ -262,5 +262,19 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
 
   private _hoverLeave(): void {
     this.setState({ showHover: false, activeLegend: '', selectedLegend: 'none', focusedArcId: '' });
+  }
+
+  private _valueInsideDonut(valueInsideDonut: string | number | undefined, data: IChartDataPoint[]) {
+    if (valueInsideDonut != undefined && this.state.activeLegend != '' && !this.state.showHover) {
+      let legendValue = valueInsideDonut;
+      data!.map((point: IChartDataPoint, index: number) => {
+        if (point.legend == this.state.activeLegend) {
+          legendValue = point.data!;
+        }
+      });
+      return legendValue;
+    } else {
+      return valueInsideDonut;
+    }
   }
 }


### PR DESCRIPTION
…oresponding to the legend.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Donut Chart: When mouse is hovered over legend, have the value appear in the center of the donut chart:

Screenshots:
Default State:
![image](https://user-images.githubusercontent.com/57419611/87488348-fddc8080-c5f4-11ea-83ba-3e502173acbe.png)

Mouse over legend state:
![image](https://user-images.githubusercontent.com/57419611/87488368-07fe7f00-c5f5-11ea-96e5-57b4ec8d8736.png)


